### PR TITLE
Add dagre/joint importmap pinning and fix dialog closing

### DIFF
--- a/app/javascript/solid_litequeen/controllers/dialog_controller.js
+++ b/app/javascript/solid_litequeen/controllers/dialog_controller.js
@@ -8,7 +8,11 @@ export default class extends Controller {
 			"click",
 			this.handleClickOusideDialog.bind(this),
 		);
-	}
+        }
+
+        close() {
+                this.element?.close();
+        }
 
 	disconnect() {
 		this.element.removeEventListener(

--- a/app/javascript/solid_litequeen/controllers/table_relations_controller.js
+++ b/app/javascript/solid_litequeen/controllers/table_relations_controller.js
@@ -1,11 +1,14 @@
 import { Controller } from "@hotwired/stimulus";
+import * as joint from "@joint/core";
+import * as dagre from "@dagrejs/dagre";
 
 // Connects to data-controller="table-relations"
 export default class extends Controller {
-	connect() {
-		const table_relations_data = JSON.parse(
-			table_relationships.dataset.relations,
-		);
+        connect() {
+                const table_relationships = document.getElementById("table_relationships");
+                const table_relations_data = JSON.parse(
+                        table_relationships.dataset.relations,
+                );
 		this.tables = table_relations_data.tables;
 		this.relations = table_relations_data.relations;
 

--- a/app/views/layouts/solid_litequeen/application.html.erb
+++ b/app/views/layouts/solid_litequeen/application.html.erb
@@ -11,8 +11,6 @@
 
   <%= stylesheet_link_tag "solid_litequeen/application", media: "all", "data-turbo-track": "reload" %>
   <script src="https://unpkg.com/@tailwindcss/browser@4"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@joint/core@4.0.1/dist/joint.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/dagre/0.8.5/dagre.min.js"></script>
   <style type="text/tailwindcss">
     @plugins "form";
 

--- a/app/views/solid_litequeen/databases/_table-relationships-dialog.html.erb
+++ b/app/views/solid_litequeen/databases/_table-relationships-dialog.html.erb
@@ -1,6 +1,6 @@
 <dialog id="table_relationships" data-controller="dialog table-relations" data-relations="<%= @table_relations.to_json %>" class="w-[1000px] h-full m-auto overscroll-y-contain">
     <form method="submit" class="flex  flex-row-reverse">
-        <button formmethod="dialog" class="cursor-pointer mr-4 mt-2 outline-none"> 
+        <button formmethod="dialog" class="cursor-pointer mr-4 mt-2 outline-none" data-action="dialog#close">
             <%= image_tag "solid_litequeen/icons/x.svg", class: "size-5" %>
         </button>
     </form>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,7 +5,7 @@ pin "application", to: "solid_litequeen/application.js", preload: true
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
-pin " @joint/core", to: "join.js", preload: false
-pin " @dagrejs/dagre", to: "dagre.min.js", preload: false
+pin "@joint/core", to: "https://ga.jspm.io/npm:@joint/core@4.0.1/dist/joint.js", preload: false
+pin "@dagrejs/dagre", to: "https://ga.jspm.io/npm:@dagrejs/dagre@0.8.5/dist/dagre.min.js", preload: false
 pin_all_from SolidLitequeen::Engine.root.join("app/javascript/solid_litequeen/controllers"), under: "controllers", to: "solid_litequeen/controllers"
 # pin_all_from SolidLitequeen::Engine.root.join("app/javascript/solid_litequeen/helpers"), under: "helpers", to: "solid_litequeen/helpers"


### PR DESCRIPTION
## Summary
- pin dagre and jointjs libraries in the engine importmap
- load dagre/joint via ES modules in `table_relations_controller`
- remove old CDN script tags from the engine layout
- add a close action on `dialog_controller`
- trigger dialog#close on the relationship dialog button

## Testing
- `bundle exec rake test` *(fails: Could not find gem 'sqlite3')*
- `bundle exec rubocop` *(fails: command not found)*