### PR TITLE
Refine dark mode with CSS variables

### DIFF
--- a/app/views/layouts/solid_litequeen/application.html.erb
+++ b/app/views/layouts/solid_litequeen/application.html.erb
@@ -16,10 +16,23 @@
   <style type="text/tailwindcss">
     @plugins "form";
 
-    :root{
+    :root {
       color-scheme: light dark;
+      --color-bg: #ffffff;
+      --color-text: #0f172a;
+      --color-surface: #ffffff;
+      --color-surface-alt: #f3f4f6;
     }
-   
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --color-bg: #0a0a0a;
+        --color-text: #ffffff;
+        --color-surface: #1f2937;
+        --color-surface-alt: #374151;
+      }
+    }
+
     @theme {
       --color-clifford: #da373d;
     }
@@ -50,7 +63,7 @@
 
   <%= yield :head %>
 </head>
-<body class="">
+<body class="bg-[var(--color-bg)] text-[var(--color-text)]">
   <header class="container mx-auto mt-4 mb-8">
     <%= render "solid_litequeen/database-selector" %>
   </header>

--- a/app/views/solid_litequeen/databases/_foreign-key-data.html.erb
+++ b/app/views/solid_litequeen/databases/_foreign-key-data.html.erb
@@ -10,7 +10,7 @@
     
     <div class="mx-auto my-4 p-4 max-w-[90%]">
         <table class="min-w-full divide-y divide-gray-200 border border-gray-200">
-            <thead class="bg-gray-50">
+            <thead class="bg-[var(--color-surface-alt)]">
                 <tr>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                         Column Name
@@ -20,7 +20,7 @@
                     </th>
                 </tr>
             </thead>
-            <tbody class="bg-white divide-y divide-gray-200">
+            <tbody class="bg-[var(--color-surface)] divide-y divide-gray-200">
                 <% @result.rows.each do |row| %>
                     <% @result.columns.zip(row).each do |column, value| %>
                         <tr>

--- a/app/views/solid_litequeen/databases/index.html.erb
+++ b/app/views/solid_litequeen/databases/index.html.erb
@@ -9,7 +9,7 @@
     <% if available_databases.any? %>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
             <% available_databases.each do |db| %>
-                <a href="<%= database_path(Base64.urlsafe_encode64(db.database)) %>" class="block bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition duration-150 overflow-hidden">
+                <a href="<%= database_path(Base64.urlsafe_encode64(db.database)) %>" class="block bg-[var(--color-surface)] rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition duration-150 overflow-hidden">
                     <div class="p-5">
                         <div class="flex items-center justify-between mb-2">
                             <h2 class="text-lg font-semibold text-gray-900 truncate"><%= db.name %></h2>
@@ -29,7 +29,7 @@
             <% end %>
         </div>
     <% else %>
-        <div class="bg-gray-50 rounded-lg p-8 text-center">
+        <div class="bg-[var(--color-surface)] rounded-lg p-8 text-center">
             <p class="text-gray-600">No databases found</p>
         </div>
     <% end %>

--- a/app/views/solid_litequeen/databases/show.html.erb
+++ b/app/views/solid_litequeen/databases/show.html.erb
@@ -24,17 +24,17 @@
         <p class="text-gray-600"><%= pluralize(@tables.count, "table") %> found</p>
     </div>
 
-    <div class="bg-white rounded-lg shadow overflow-hidden">
+    <div class="bg-[var(--color-surface)] rounded-lg shadow overflow-hidden">
         <table class="w-full">
             <thead>
-                <tr class="bg-gray-100 border-b border-gray-200">
+                <tr class="bg-[var(--color-surface-alt)] border-b border-gray-200">
                     <th class="px-6 py-3 text-left text-sm font-medium text-gray-700">Table Name</th>
                     <th class="px-6 py-3 text-left text-sm font-medium text-gray-700">Row Count</th>
                 </tr>
             </thead>
             <tbody class="divide-y divide-gray-200">
                 <% @tables.each do |table| %>
-                    <tr class="hover:bg-gray-50">
+                    <tr class="hover:bg-[var(--color-surface-alt)]">
                         <td class="px-6 py-4">
                             <%= link_to database_table_rows_path(@database_id, table[:name]), class: "text-blue-600 hover:text-blue-800 font-medium" do %>
                                 <%= table.dig(:name) %>

--- a/app/views/solid_litequeen/databases/table_rows.html.erb
+++ b/app/views/solid_litequeen/databases/table_rows.html.erb
@@ -15,7 +15,7 @@
         <p class="text-gray-600"><%= pluralize(@row_count, "row") %> found</p>
     </div>
 
-    <div class="bg-white rounded-lg shadow overflow-x-auto">
+    <div class="bg-[var(--color-surface)] rounded-lg shadow overflow-x-auto">
         <div class="min-w-full inline-block align-middle">
             <table 
                 data-controller="table" 
@@ -24,7 +24,7 @@
                 class="min-w-full relative"
                 >
                 <thead class="">
-                    <tr class="bg-gray-100 border-b border-gray-200">
+                    <tr class="bg-[var(--color-surface-alt)] border-b border-gray-200">
                         <% @data.columns.each_with_index do |column, index| %>
                             <th 
                                 draggable="true" 
@@ -40,10 +40,10 @@
                                            <%= image_tag "solid_litequeen/icons/info.svg", class: "size-3.5" %>
                                 </button>
                                 
-                                <div popover id="<%= popover_id %>"  class="max-w-lg min-h-10 bg-gray-100 border-gray-400 border p-4 rounded-md" style="position-anchor: --anchor_<%= popover_id%>;  top: anchor(--anchor_<%= popover_id%> bottom);  left: anchor(--anchor_<%= popover_id%> right);">
+                                <div popover id="<%= popover_id %>"  class="max-w-lg min-h-10 bg-[var(--color-surface-alt)] border-gray-400 border p-4 rounded-md" style="position-anchor: --anchor_<%= popover_id%>;  top: anchor(--anchor_<%= popover_id%> bottom);  left: anchor(--anchor_<%= popover_id%> right);">
                                     <table class="min-w-full divide-y divide-gray-200 border border-gray-200">
                                       
-                                        <tbody class="bg-white divide-y divide-gray-200">
+                                        <tbody class="bg-[var(--color-surface)] divide-y divide-gray-200">
                                             <% column_info = @columns_info[column]  %>
                                            
                                             <tr>
@@ -142,7 +142,7 @@
                 
                 <tbody class="divide-y divide-gray-200">
                     <% @data.rows.each do |row| %>
-                        <tr class="hover:bg-gray-50" >
+                        <tr class="hover:bg-[var(--color-surface-alt)]" >
                             <% row.each_with_index do |item, index| %>
                                 <% truncated_item =  item&.truncate(80) %>
                                 <% column_name = @data.columns[index] %>


### PR DESCRIPTION
## Summary
- revert unwanted Gemfile.lock and website changes
- add CSS variable night mode for Rails engine templates
- use theme variables for table and card surfaces

## Testing
- `bundle exec rake test` *(no tests run)*
- `npm run lint` *(fails: `next` not found)*