### PR TITLE
Improve JSON display in row dialogs

### DIFF
--- a/app/views/solid_litequeen/databases/_table-data-context-dialog.html.erb
+++ b/app/views/solid_litequeen/databases/_table-data-context-dialog.html.erb
@@ -8,8 +8,23 @@
     <h1 class="text-lg font-semibold text-center"><%= column_name %></h1>
 
     <div class="flex items-center max-w-[90%] h-80 max-h-80 mx-auto my-4 p-2 dark:bg-transparent  bg-gray-100  dark:border dark:border-gray-50/50 rounded ">
-        <p class="text-wrap overflow-auto w-[inherit] h-[inherit] p-2">
-            <%= data %>
-        </p>
+        <% 
+            pretty_data = data
+            is_json = false
+
+            if data.is_a?(String)
+              begin
+                pretty_data = JSON.pretty_generate(JSON.parse(data))
+                is_json = true
+              rescue JSON::ParserError
+              end
+            end
+        %>
+
+        <% if is_json %>
+            <pre class="text-wrap overflow-auto w-[inherit] h-[inherit] p-2"><%= pretty_data %></pre>
+        <% else %>
+            <p class="text-wrap overflow-auto w-[inherit] h-[inherit] p-2"><%= pretty_data %></p>
+        <% end %>
     </div>
 </dialog>


### PR DESCRIPTION
## Summary
- format JSON values in table row dialogs so they are easier to read

## Testing
- `bundle exec rails test` *(fails: SolidLitequeen::DatabasesControllerTest#test_enum_mappings_include_article_status)*

------
https://chatgpt.com/codex/tasks/task_b_6853781928908329939a4cbbf51b27b5