### PR TITLE
Fix command palette closing

### DIFF
--- a/app/javascript/solid_litequeen/controllers/command_palette_controller.js
+++ b/app/javascript/solid_litequeen/controllers/command_palette_controller.js
@@ -55,7 +55,7 @@ export default class extends Controller {
 
         // Click outside to close
         this.modal.addEventListener('click', (e) => {
-            if (e.target === this.modal) {
+            if (!this.dialog.contains(e.target)) {
                 this.close();
             }
         });


### PR DESCRIPTION
## Summary
- close command palette when clicking outside of the dialog

## Testing
- `bundle exec rails test` *(fails: `NameError: uninitialized constant SolidLitequeen::DynamicDatabase`)*

------
https://chatgpt.com/codex/tasks/task_b_6874f6ce227c832994386b91c51003ed