### PR TITLE
Update website URLs to litequeen.vikborges.com

### DIFF
--- a/website/scripts/build.ts
+++ b/website/scripts/build.ts
@@ -21,7 +21,7 @@ import guidePosts from '../src/app/guides/posts.json'
 
 const ROOT = path.resolve(import.meta.dir, '..')
 const DIST = path.join(ROOT, 'dist')
-const SITE_URL = 'https://solid.litequeen.com'
+const SITE_URL = 'https://litequeen.vikborges.com'
 const TITLE = 'Solid Lite Queen - Manage SQLite databases in your Rails app'
 const DESCRIPTION =
   'Solid Lite Queen is an open-source SQLite database management software for your Rails app.'

--- a/website/src/app/_feed.xml/route.js
+++ b/website/src/app/_feed.xml/route.js
@@ -3,9 +3,9 @@ import * as cheerio from "cheerio";
 import { Feed } from "feed";
 
 export async function GET(req) {
-	let siteUrl = "https://solid.litequeen.com";
+	let siteUrl = "https://litequeen.vikborges.com";
 	// let rssSourceUrl = process.env.NEXT_PUBLIC_SITE_URL;
-	let rssSourceUrl = "https://solid.litequeen.com";
+	let rssSourceUrl = "https://litequeen.vikborges.com";
 
 	if (!siteUrl) {
 		throw Error("Missing NEXT_PUBLIC_SITE_URL environment variable");

--- a/website/src/app/layout.jsx
+++ b/website/src/app/layout.jsx
@@ -10,10 +10,10 @@ export const metadata = {
     'Solid Lite Queen is an open-source SQLite database management software for your Rails app.',
   alternates: {
     types: {
-      'application/rss+xml': 'https://solid.litequeen.com/feed.xml',
+      'application/rss+xml': 'https://litequeen.vikborges.com/feed.xml',
     },
   },
-  metadataBase: new URL('https://solid.litequeen.com'),
+  metadataBase: new URL('https://litequeen.vikborges.com'),
 }
 
 export default function RootLayout({ children }) {

--- a/website/src/app/robots.js
+++ b/website/src/app/robots.js
@@ -7,6 +7,6 @@ export default function robots() {
 				// disallow: [""],
 			},
 		],
-		sitemap: "https://solid.litequeen.com/sitemap.xml",
+		sitemap: "https://litequeen.vikborges.com/sitemap.xml",
 	};
 }

--- a/website/src/app/sitemap.js
+++ b/website/src/app/sitemap.js
@@ -16,27 +16,27 @@ export default async function sitemap() {
 
 	return [
 		{
-			url: "https://solid.litequeen.com/",
+			url: "https://litequeen.vikborges.com/",
 			lastModified: new Date(),
 			changeFrequency: "daily",
 			priority: 1,
 		},
 
 		{
-			url: "https://solid.litequeen.com/guides/",
+			url: "https://litequeen.vikborges.com/guides/",
 			lastModified: new Date(),
 			changeFrequency: "daily",
 			priority: 1,
 		},
 		// {
-		// 	url: "https://solid.litequeen.com/faq/",
+		// 	url: "https://litequeen.vikborges.com/faq/",
 		// 	lastModified: new Date(),
 		// 	changeFrequency: "daily",
 		// 	priority: 1,
 		// },
 
 		...posts.map((post) => ({
-			url: `https://solid.litequeen.com/guides/${post.slug}`,
+			url: `https://litequeen.vikborges.com/guides/${post.slug}`,
 			lastModified: new Date(),
 			changeFrequency: "daily",
 			priority: 1,

--- a/website/src/components/Intro.jsx
+++ b/website/src/components/Intro.jsx
@@ -27,7 +27,7 @@ export function Intro() {
           </a>
 
           {/* <a
-						href="https://demo.solid.litequeen.com"
+						href="https://litequeen.vikborges.com"
 						target="_blank"
 						rel="noreferrer"
 						data-umami-event="Demo button"


### PR DESCRIPTION
This updates the website domain references from solid.litequeen.com to litequeen.vikborges.com across the marketing site metadata and generated outputs. It covers the site build URL, RSS/feed URL, robots sitemap URL, sitemap entries, and the remaining demo link reference.